### PR TITLE
Add support for Windows Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ MSSQL_SERVER=localhost
 MSSQL_USER=your_username
 MSSQL_PASSWORD=your_password
 MSSQL_DATABASE=your_database
+MSSQL_USE_WINDOWS_AUTH=true  # Set to true to use Windows Authentication
 ```
 
 ## Usage
@@ -51,7 +52,8 @@ Add this to your `claude_desktop_config.json`:
         "MSSQL_SERVER": "localhost",
         "MSSQL_USER": "your_username",
         "MSSQL_PASSWORD": "your_password",
-        "MSSQL_DATABASE": "your_database"
+        "MSSQL_DATABASE": "your_database",
+        "MSSQL_USE_WINDOWS_AUTH": "true"  # Set to true to use Windows Authentication
       }
     }
   }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,6 +89,7 @@ MSSQL_SERVER=your_server
 MSSQL_USER=mcp_login
 MSSQL_PASSWORD=your_secure_password
 MSSQL_DATABASE=your_database
+MSSQL_USE_WINDOWS_AUTH=true  # Set to true to use Windows Authentication
 ```
 
 ### Monitoring Usage


### PR DESCRIPTION
Add support for Windows Authentication for SQL Server connections.

* **src/mssql_mcp_server/server.py**
  - Check for `MSSQL_USE_WINDOWS_AUTH` environment variable.
  - Use `trusted_connection='yes'` if `MSSQL_USE_WINDOWS_AUTH` is set to `true`.
  - Remove `user` and `password` from config if using Windows Authentication.
  - Log database config with user or Windows Authentication.

* **README.md**
  - Update configuration section to include `MSSQL_USE_WINDOWS_AUTH` environment variable.

* **SECURITY.md**
  - Mention the option of using Windows Authentication for SQL Server connections.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yulin0629/mssql_mcp_server/pull/1?shareId=c0ec442b-7bea-4675-ab37-0c16f865ca0f).